### PR TITLE
Rewrite shell.nix to use shellFor and callCabal2nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,30 +1,21 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+{ pkgs ? import <nixpkgs> {}, compiler ? "default" }:
 
 let
 
-  inherit (nixpkgs) pkgs;
+  haskellPackages =
+    if compiler == "default"
+    then pkgs.haskellPackages
+    else pkgs.haskell.packages.${compiler};
 
-  f = { mkDerivation, base, containers, lens, linear, megaparsec
-      , mtl, pretty-show, recursion-schemes, stdenv, text, transformers
-      , diagrams
-      }:
-      mkDerivation {
-        pname = "gerber";
-        version = "0.1.0.0";
-        src = ./.;
-        libraryHaskellDepends = [
-          base containers lens linear megaparsec mtl pretty-show
-          recursion-schemes text transformers diagrams
-        ];
-        license = stdenv.lib.licenses.mit;
-      };
+  inherit (haskellPackages) callCabal2nix;
 
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  drv = haskellPackages.callPackage f {};
+  gerber = callCabal2nix "gerber" ./gerber {};
+  gerber-diagrams = callCabal2nix "gerber-diagrams" ./gerber-diagrams {
+    inherit gerber;
+  };
 
 in
 
-  if pkgs.lib.inNixShell then drv.env else drv
+haskellPackages.shellFor {
+  packages = p: [ gerber gerber-diagrams ];
+}


### PR DESCRIPTION
The old `shell.nix` manually listed the dependencies required by the shell. Worse, this manual list was out of sync with the actual dependencies needed by `gerber` and `gerber-diagrams`; e.g., it listed `diagrams` as a dependency, which was failing because of an upper bound in one of `diagrams-contrib`'s dependencies, but `gerber-diagrams` doesn't even need `diagrams`, it only needs `diagrams-lib` and `diagrams-cairo`. Using `callCabal2nix` and `shellFor` will automatically generate a shell with the exact dependencies specified by in the cabal files.