### PR TITLE
Change memory layout of EncodedDecimal

### DIFF
--- a/gerber/lib/Gerber/EncodedDecimal.hs
+++ b/gerber/lib/Gerber/EncodedDecimal.hs
@@ -1,9 +1,53 @@
-module Gerber.EncodedDecimal ( EncodedDecimal(..) ) where
+{-# language DeriveGeneric #-}
+{-# language DeriveAnyClass #-}
+{-# language PatternSynonyms #-}
+{-# language ViewPatterns #-}
+{-# language BangPatterns #-}
+{-# language FlexibleContexts #-}
+{-# language NamedFieldPuns #-}
+
+module Gerber.EncodedDecimal ( EncodedDecimal(EncodedDecimal, StoredEncodedDecimal), negative, digits ) where
+
+import Data.Int
+import Data.Word
+
+pattern EncodedDecimal :: Bool -> [ Int ] -> EncodedDecimal
+pattern EncodedDecimal {negative, digits} <- (toEncoded -> (negative, digits)) where
+  EncodedDecimal n d = fromEncoded n d
+
+{-# COMPLETE EncodedDecimal #-}
 
 data EncodedDecimal =
-  EncodedDecimal
-    { negative :: Bool
-    , digits :: [ Int ]
+  StoredEncodedDecimal
+    { width :: {-# UNPACK #-} !Word8
+    , digitsAsInt :: {-# UNPACK #-} !Int32
     }
   deriving
-    ( Eq, Show )
+    ( Eq )
+
+instance Show EncodedDecimal where
+   show EncodedDecimal{negative = n, digits = d} =
+    "EncodedDecimal {negative = " ++ show n ++ ", digits = " ++ show d ++ "}"
+
+
+toEncoded :: EncodedDecimal -> (Bool, [ Int ])
+toEncoded StoredEncodedDecimal {width, digitsAsInt} = (digitsAsInt < 0, reverse (go 0 (fromIntegral (abs digitsAsInt))))
+  where
+    go :: Word8 -> Int -> [Int]
+    go !currentWidth !num
+      | currentWidth == width = []
+      | otherwise = num `mod` 10 : go (currentWidth + 1) (num `div` 10)
+
+fromEncoded :: Bool -> [Int] -> EncodedDecimal
+fromEncoded isNegative digitList =
+  StoredEncodedDecimal
+    { width = fromIntegral (length digitList)
+    , digitsAsInt = fromIntegral . doNegation . go 1 0 . reverse $ digitList
+    }
+  where
+    go _ !sum_ [] = sum_
+    go !magnitude !sum_ (digit:digits_) = go (magnitude * 10) (sum_ + magnitude * digit) digits_
+
+    doNegation
+      | isNegative = negate
+      | otherwise = id


### PR DESCRIPTION
The `EncodedDecimal` type was correct for representing encoded decimals
in the Gerber standard but it was a terribly wasteful way to store
numbers which are used as coordinates and which dominate a Gerber file.
For processing large Gerber files (over a 100 MB) it lead to a memory
explosion.

To fix this we keep the interface of the `EncodedDecimal` constructor
but we change the representation to more efficient packed number format.
All the tests still pass without modification.

In another branch I added binary serialization to the Gerber command and
before the change a 100 MB Gerber file would be serialized as a 500 MB
binary file but after the size is basically the same.