### PR TITLE
Fix arc full circle detection

### DIFF
--- a/gerber-diagrams/lib/Gerber/Diagrams.hs
+++ b/gerber-diagrams/lib/Gerber/Diagrams.hs
@@ -74,7 +74,7 @@ gerberToDiagramCustom config =
                   ( realToFrac <$> Diagrams.r2 center )
                   ( Diagrams.scale
                       ( realToFrac ( Diagrams.norm toStart ) )
-                      ( if Linear.nearZero ( toStart .-. toEnd ) then
+                      ( if all Linear.nearZero ( toStart .-. toEnd ) then
                           Diagrams.arc'
                             1
                             ( realToFrac <$> Diagrams.direction toStart )
@@ -221,7 +221,7 @@ fromEdges currentPoint ( Edge.ArcCW center end : edges ) =
       Diagrams.p2 end .-. Diagrams.p2 center
 
     arc =
-      if Linear.nearZero ( Diagrams.p2 currentPoint .-. Diagrams.p2 end ) then
+      if all Linear.nearZero ( Diagrams.p2 currentPoint .-. Diagrams.p2 end ) then
         -- S2.12 states:
         --
         -- Multi quadrant mode: mode defining how circular interpolation is
@@ -253,7 +253,7 @@ fromEdges currentPoint ( Edge.ArcCCW center end : edges ) =
       Diagrams.p2 end .-. Diagrams.p2 center
 
     arc =
-      if Linear.nearZero ( Diagrams.p2 currentPoint .-. Diagrams.p2 end ) then
+      if all Linear.nearZero ( Diagrams.p2 currentPoint .-. Diagrams.p2 end ) then
         -- S2.12 states:
         --
         -- Multi quadrant mode: mode defining how circular interpolation is


### PR DESCRIPTION
To decide between zero length arcs and full circle arcs a check was
done to see if the start and endpoints are coincident. According to the
specification if the points are coincident then the arc is a full
circle. Unfortunately the `Epsilon` instance of `V2` was used to check
whether the difference vector was near zero. The problem is that it
checks whether the square of the norm of the vector is close to zero.
Instead on needs to check whether each component of the vector is close
to zero, otherwise your precision is greatly diminished.

`nearZero` on `V2`

```
nearZero (V2 (5.0e-4) (5.0e-4::Float)) = True
```

Component wise `nearZero` on `V2`

```
all nearZero (V2 (5.0e-4) (5.0e-4::Float)) = False
```

This is a problem in practice since users / EDA tools sometimes generate
almost zero length almost straight arcs and currently this gets drawn as
a huge circle instead of an almost invisible line segment.

Here is a minimal example of such a case:

```
G04*
G04 #@! TF.GenerationSoftware,Altium Limited,Altium Designer,20.2.6 (244)*
G04*
G04 Layer_Physical_Order=5*
G04 Layer_Color=128*
%FSLAX44Y44*%
%MOMM*%
G71*
G04*
G04 #@! TF.SameCoordinates,28457D97-D734-470E-A553-1EBF0831B7FB*
G04*
G04*
G04 #@! TF.FilePolarity,Negative*
G04*
G01*
G75*
%ADD40C,0.5000*%
%ADD46C,1.0160*%
%ADD47C,1.9000*%
%ADD48C,1.2500*%
D40*
D02*
X226640Y542D02*
G03*
X226643Y538I476648J245406D01*
G01*
M02*
```