### PR TITLE
Reformat all repository code with new formatting configuration

### DIFF
--- a/gerber-diagrams/exe/Main.hs
+++ b/gerber-diagrams/exe/Main.hs
@@ -3,10 +3,7 @@
 
 module Main where
 
--- 
-import RIO
-
--- diagrams-gi-cairo
+-- diagrams-cairo
 import qualified Diagrams.Backend.Cairo
 
 -- diagrams-lib
@@ -24,6 +21,9 @@ import Gerber.Diagrams (gerberToDiagram)
 
 -- optparse-applicative
 import qualified Options.Applicative as OptParse
+
+-- rio
+import RIO
 
 -- text
 import qualified Data.Text.IO as StrictText

--- a/gerber-diagrams/lib/Gerber/Diagrams.hs
+++ b/gerber-diagrams/lib/Gerber/Diagrams.hs
@@ -225,7 +225,6 @@ fromEdges currentPoint (Edge.ArcCW center end : edges) =
         -- performed. In this mode a circular arc is allowed to extend over more
         -- than 90°. If the start point of the arc is equal to the end point the arc
         -- is a full circle of 360°.
-
           Diagrams.arc
             (realToFrac <$> Diagrams.direction toStart)
             (1 Diagrams.@@ Diagrams.turn)
@@ -253,7 +252,6 @@ fromEdges currentPoint (Edge.ArcCCW center end : edges) =
         -- performed. In this mode a circular arc is allowed to extend over more
         -- than 90°. If the start point of the arc is equal to the end point the arc
         -- is a full circle of 360°.
-
           Diagrams.arc
             (realToFrac <$> Diagrams.direction toStart)
             (1 Diagrams.@@ Diagrams.turn)
@@ -462,8 +460,7 @@ renderMacro = foldMap Diagrams.stroke . foldl' addToOnPaths [] . concatMap (expl
           ,
             [ rotate
                 (MacroDefinition.thermalRotation a)
-                ( Diagrams.translate (MacroDefinition.thermalCenter a) thermal
-                )
+                (Diagrams.translate (MacroDefinition.thermalCenter a) thermal)
             ]
           )
           where

--- a/gerber-diagrams/tests/Gerber/Diagrams/Tests.hs
+++ b/gerber-diagrams/tests/Gerber/Diagrams/Tests.hs
@@ -2,7 +2,7 @@
 
 module Gerber.Diagrams.Tests (tests) where
 
--- diagrams-gi-cairo
+-- diagrams-cairo
 import qualified Diagrams.Backend.Cairo
 
 -- diagrams-lib

--- a/gerber/lib/Gerber/Grammar.hs
+++ b/gerber/lib/Gerber/Grammar.hs
@@ -977,7 +977,6 @@ apertureAttribute =
       , flashTextParser
       ]
   where
-
     -- sometimes the string looks like 'Pad Free-** (29.8mm,10.575mm)' in '%TA.AperFunction,OtherDrill,Pad Free-** (29.8mm,10.575mm)*%'
     -- that is why we don't re-use `string` below
     restAsString =
@@ -1023,7 +1022,7 @@ apertureAttribute =
             , AperFunction.NonMaterial <$ Megaparsec.string "NonMaterial"
             , AperFunction.Material <$ Megaparsec.string "Material"
             , AperFunction.Other <$> (Megaparsec.string "Other," *> restAsString)
-            , Megaparsec.string "Drawing" *>  restAsString *> pure AperFunction.Drawing
+            , Megaparsec.string "Drawing" *> restAsString *> pure AperFunction.Drawing
             , Megaparsec.string "CutOut" *> restAsString *> pure AperFunction.CutOut
             , Megaparsec.string "Slot" *> restAsString *> pure AperFunction.Slot
             , Megaparsec.string "Cavity" *> restAsString *> pure AperFunction.Cavity

--- a/shell.nix
+++ b/shell.nix
@@ -20,36 +20,68 @@ let
 
   ch-hs-imports =
     pkgs.haskellPackages.callPackage
-    ({ mkDerivation, abstract-par, base, containers, deepseq, directory
-    , dlist, fetchgit, filepath, lib, megaparsec, monad-par
-    , monad-par-extras, monoidal-containers, mtl, nonempty-containers
-    , optparse-applicative, process, text, transformers
-    }:
-    mkDerivation {
-      pname = "ch-hs-imports";
-      version = "0.1.0.0";
-      src = fetchgit {
-        url = "https://github.com/circuithub/ch-hs-imports";
-        sha256 = "1ayg2pbzgy3zwb14f084s4rbp0qaxn6fygg3l4avj7pc7kxb1z2j";
-        rev = "7e5b0bc5bc9dde28015784e9a61270a031a126dc";
-        fetchSubmodules = true;
-      };
-      isLibrary = false;
-      isExecutable = true;
-      executableHaskellDepends = [
-        abstract-par base containers deepseq directory dlist filepath
-        megaparsec monad-par monad-par-extras monoidal-containers mtl
-        nonempty-containers optparse-applicative process text transformers
-      ];
-      jailbreak = true;
-      license = lib.licenses.mit;
-      mainProgram = "ch-hs-imports";
-    }) {};
+      ({ mkDerivation
+       , abstract-par
+       , base
+       , containers
+       , deepseq
+       , directory
+       , dlist
+       , fetchgit
+       , filepath
+       , lib
+       , megaparsec
+       , monad-par
+       , monad-par-extras
+       , monoidal-containers
+       , mtl
+       , nonempty-containers
+       , optparse-applicative
+       , process
+       , text
+       , transformers
+       }:
+        mkDerivation {
+          pname = "ch-hs-imports";
+          version = "0.1.0.0";
+          src = fetchgit {
+            url = "https://github.com/circuithub/ch-hs-imports";
+            sha256 = "1ayg2pbzgy3zwb14f084s4rbp0qaxn6fygg3l4avj7pc7kxb1z2j";
+            rev = "7e5b0bc5bc9dde28015784e9a61270a031a126dc";
+            fetchSubmodules = true;
+          };
+          isLibrary = false;
+          isExecutable = true;
+          executableHaskellDepends = [
+            abstract-par
+            base
+            containers
+            deepseq
+            directory
+            dlist
+            filepath
+            megaparsec
+            monad-par
+            monad-par-extras
+            monoidal-containers
+            mtl
+            nonempty-containers
+            optparse-applicative
+            process
+            text
+            transformers
+          ];
+          jailbreak = true;
+          license = lib.licenses.mit;
+          mainProgram = "ch-hs-imports";
+        })
+      { };
 
 in
 haskellPackages.shellFor {
   buildInputs =
-    [ haskellPackages.cabal-install
+    [
+      haskellPackages.cabal-install
       pkgs.treefmt
       pkgs.nixpkgs-fmt
       haskellPackages.haskell-language-server


### PR DESCRIPTION
We reformat the code using treefmt and our newly added formatting configuration.