### PR TITLE
Sanitation: bump versions set dep bounds build no warnings

### DIFF
--- a/gerber-diagrams/gerber-diagrams.cabal
+++ b/gerber-diagrams/gerber-diagrams.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               gerber-diagrams
-version:            0.2.0.0
+version:            0.3.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Oliver Charles
@@ -15,11 +15,11 @@ extra-source-files:
 library
   exposed-modules:  Gerber.Diagrams
   build-depends:
-    , base
-    , diagrams-contrib
-    , diagrams-lib
-    , gerber
-    , linear
+    , base              >=4.20 && <4.21
+    , diagrams-contrib  >=1.4  && <1.5
+    , diagrams-lib      >=1.5  && <1.6
+    , gerber            >=0.4  && <0.5
+    , linear            >=1.23 && <1.24
 
   hs-source-dirs:   lib
   default-language: Haskell2010
@@ -29,19 +29,21 @@ library
     -Wno-missing-local-signatures -Wno-monomorphism-restriction
     -Wno-unsafe -Wno-safe -Wno-all-missed-specialisations
     -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+    -Wno-missing-kind-signatures -Wno-missing-role-annotations
+    -Wno-missed-specialisations -Wno-name-shadowing -Wno-partial-fields
 
 executable render-gerbers
   hs-source-dirs:   exe
   build-depends:
-    , base
-    , diagrams-gi-cairo
-    , diagrams-lib
-    , foldl
+    , base                  >=4.20 && <4.21
+    , diagrams-gi-cairo     >=1.5  && <1.6
+    , diagrams-lib          >=1.5  && <1.6
+    , foldl                 >=1.4  && <1.5
     , gerber
     , gerber-diagrams
-    , optparse-applicative
-    , rio
-    , text
+    , optparse-applicative  >=0.18 && <0.19
+    , rio                   >=0.1  && <0.2
+    , text                  >=2.1  && <2.2
 
   default-language: Haskell2010
   ghc-options:      -Wall
@@ -49,23 +51,23 @@ executable render-gerbers
 
 test-suite tests
   build-depends:
-    , base
-    , bytestring
-    , containers
-    , diagrams-cairo
-    , diagrams-lib
-    , directory
-    , foldl
-    , generic-deriving
+    , base              >=4.20 && <4.21
+    , bytestring        >=0.12 && <0.13
+    , containers        >=0.7  && <0.8
+    , diagrams-cairo    >=1.5  && <1.6
+    , diagrams-lib      >=1.5  && <1.6
+    , directory         >=1.3  && <1.4
+    , foldl             >=1.4  && <1.5
+    , generic-deriving  >=1.14 && <1.15
     , gerber
     , gerber-diagrams
-    , linear
-    , megaparsec
-    , monoid-extras
-    , pretty-show
-    , tasty
-    , tasty-golden
-    , text
+    , linear            >=1.23 && <1.24
+    , megaparsec        >=9.7  && <9.8
+    , monoid-extras     >=0.7  && <0.8
+    , pretty-show       >=1.10 && <1.11
+    , tasty             >=1.5  && <1.6
+    , tasty-golden      >=2.3  && <2.4
+    , text              >=2.1  && <2.2
 
   main-is:          Main.hs
   hs-source-dirs:   tests

--- a/gerber-diagrams/lib/Gerber/Diagrams.hs
+++ b/gerber-diagrams/lib/Gerber/Diagrams.hs
@@ -17,7 +17,7 @@ module Gerber.Diagrams (
 ) where
 
 -- base
-import Data.List (foldl', unfoldr)
+import Data.List (unfoldr)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Typeable (Typeable)
 

--- a/gerber/gerber.cabal
+++ b/gerber/gerber.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               gerber
-version:            0.3.0.0
+version:            0.4.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Oliver Charles
@@ -55,19 +55,19 @@ library
     Gerber.Unit
 
   build-depends:
-    , base
-    , base16-bytestring
-    , bytestring
-    , containers
-    , foldl
-    , generic-deriving
-    , linear
-    , megaparsec
-    , monoid-extras
-    , mtl
-    , text
-    , time
-    , uuid-types
+    , base               >=4.20 && <4.21
+    , base16-bytestring  >=1.0  && <1.1
+    , bytestring         >=0.12 && <0.13
+    , containers         >=0.7  && <0.8
+    , foldl              >=1.4  && <1.5
+    , generic-deriving   >=1.14 && <1.15
+    , linear             >=1.23 && <1.24
+    , megaparsec         >=9.7  && <9.8
+    , monoid-extras      >=0.7  && <0.8
+    , mtl                >=2.3  && <2.4
+    , text               >=2.1  && <2.2
+    , time               >=1.12 && <1.13
+    , uuid-types         >=1.0  && <1.1
 
   hs-source-dirs:   lib
   default-language: Haskell2010
@@ -77,26 +77,28 @@ library
     -Wno-missing-local-signatures -Wno-monomorphism-restriction
     -Wno-unsafe -Wno-safe -Wno-all-missed-specialisations
     -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+    -Wno-missing-kind-signatures -Wno-missing-role-annotations
+    -Wno-missed-specialisations -Wno-name-shadowing -Wno-partial-fields
 
 test-suite tests
   build-depends:
-    , base
-    , bytestring
-    , containers
-    , directory
-    , foldl
-    , generic-deriving
+    , base              >=4.20 && <4.21
+    , bytestring        >=0.12 && <0.13
+    , containers        >=0.7  && <0.8
+    , directory         >=1.3  && <1.4
+    , foldl             >=1.4  && <1.5
+    , generic-deriving  >=1.14 && <1.15
     , gerber
-    , hedgehog
-    , hedgehog-classes
-    , linear
-    , megaparsec
-    , monoid-extras
-    , pretty-show
-    , tasty
-    , tasty-golden
-    , tasty-hedgehog
-    , text
+    , hedgehog          >=1.5  && <1.6
+    , hedgehog-classes  >=0.2  && <0.3
+    , linear            >=1.23 && <1.24
+    , megaparsec        >=9.7  && <9.8
+    , monoid-extras     >=0.7  && <0.8
+    , pretty-show       >=1.10 && <1.11
+    , tasty             >=1.5  && <1.6
+    , tasty-golden      >=2.3  && <2.4
+    , tasty-hedgehog    >=1.4  && <1.5
+    , text              >=2.1  && <2.2
 
   main-is:          Main.hs
   hs-source-dirs:   tests

--- a/gerber/lib/Gerber/Attribute.hs
+++ b/gerber/lib/Gerber/Attribute.hs
@@ -6,7 +6,7 @@ module Gerber.Attribute (
 
 -- gerber
 import Gerber.Attribute.AperFunction
-import Gerber.Attribute.Attribute
+import Gerber.Attribute.Attribute ()
 import Gerber.Attribute.CreationDate
 import Gerber.Attribute.FileFunction
 import Gerber.Attribute.FilePolarity

--- a/gerber/lib/Gerber/Attribute/CreationDate.hs
+++ b/gerber/lib/Gerber/Attribute/CreationDate.hs
@@ -12,16 +12,12 @@ import Control.Applicative (many, (<|>))
 -- containers
 import qualified Data.Set as Set
 
--- gerber
-import Gerber.Attribute.Attribute (Field)
-
 -- megaparsec
 import qualified Text.Megaparsec as Megaparsec
 import qualified Text.Megaparsec.Char as Megaparsec
 import Text.Megaparsec.Error
 
 -- text
-import Data.Text (unpack)
 import qualified Data.Text as StrictText
 
 -- time

--- a/gerber/lib/Gerber/Attribute/FilePolarity.hs
+++ b/gerber/lib/Gerber/Attribute/FilePolarity.hs
@@ -4,12 +4,6 @@ module Gerber.Attribute.FilePolarity (
   FilePolarity (..),
 ) where
 
--- gerber
-import Gerber.Attribute.Attribute (Field)
-
--- text
-import Data.Text (unpack)
-
 
 data FilePolarity
   = Positive

--- a/gerber/lib/Gerber/Attribute/ProjectId.hs
+++ b/gerber/lib/Gerber/Attribute/ProjectId.hs
@@ -6,12 +6,6 @@ module Gerber.Attribute.ProjectId (
   projectIdParser,
 ) where
 
--- base16-bytestring
-import Data.ByteString.Base16 (decode)
-
--- bytestring
-import qualified Data.ByteString.Lazy
-
 -- containers
 import qualified Data.Set as Set
 
@@ -25,7 +19,6 @@ import Text.Megaparsec.Error
 
 -- text
 import qualified Data.Text as StrictText
-import qualified Data.Text.Lazy as LazyText
 
 -- uuid-types
 import Data.UUID.Types (UUID, fromText)

--- a/gerber/lib/Gerber/EncodedDecimal.hs
+++ b/gerber/lib/Gerber/EncodedDecimal.hs
@@ -8,7 +8,6 @@ module Gerber.EncodedDecimal (EncodedDecimal (EncodedDecimal, StoredEncodedDecim
 
 -- base
 import Data.Int
-import Data.List (foldl')
 import Data.Word
 
 

--- a/gerber/lib/Gerber/Grammar.hs
+++ b/gerber/lib/Gerber/Grammar.hs
@@ -768,25 +768,6 @@ field :: Megaparsec.MonadParsec e StrictText.Text m => m StrictText.Text
 field = StrictText.pack <$> (Megaparsec.string "," *> many (Megaparsec.noneOf [',', '*', '%']))
 
 
-username :: Megaparsec.MonadParsec e StrictText.Text m => m StrictText.Text
-username =
-  let
-    lowerUpper =
-      Megaparsec.oneOf ['a' .. 'z']
-        <|> Megaparsec.oneOf ['A' .. 'Z']
-
-    startChar =
-      Megaparsec.char '_' <|> lowerUpper <|> Megaparsec.char '$'
-
-    otherChar =
-      Megaparsec.char '.' <|> Megaparsec.char '_' <|> lowerUpper <|> Megaparsec.oneOf ['0' .. '9']
-   in
-    Megaparsec.label "username" $ do
-      first <- startChar
-      rest <- many otherChar
-      pure $ StrictText.pack (first : rest)
-
-
 fileAttribute :: Megaparsec.MonadParsec e StrictText.Text m => m Gerber.Attribute.FileAttribute
 fileAttribute =
   asum $


### PR DESCRIPTION
We set the dependency bounds to what are available in the nix shell at the moment and also bump the version numbers for both libraries.

We also the enabled warnings to match most of the code in the repository and remove all outstanding build warnings so that we have a clean warning free build.