### PR TITLE
Relax lower version bounds

### DIFF
--- a/gerber-diagrams/gerber-diagrams.cabal
+++ b/gerber-diagrams/gerber-diagrams.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               gerber-diagrams
-version:            0.3.0.0
+version:            0.4.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Oliver Charles
@@ -15,11 +15,11 @@ extra-source-files:
 library
   exposed-modules:  Gerber.Diagrams
   build-depends:
-    , base              >=4.20 && <4.21
+    , base              >=4.17 && <4.21
     , diagrams-contrib  >=1.4  && <1.5
-    , diagrams-lib      >=1.5  && <1.6
-    , gerber            >=0.4  && <0.5
-    , linear            >=1.23 && <1.24
+    , diagrams-lib      >=1.4  && <1.6
+    , gerber            >=0.4  && <0.6
+    , linear            >=1.22 && <1.24
 
   hs-source-dirs:   lib
   default-language: Haskell2010
@@ -35,15 +35,15 @@ library
 executable render-gerbers
   hs-source-dirs:   exe
   build-depends:
-    , base                  >=4.20 && <4.21
-    , diagrams-gi-cairo     >=1.5  && <1.6
-    , diagrams-lib          >=1.5  && <1.6
+    , base                  >=4.17 && <4.21
+    , diagrams-gi-cairo     >=1.4  && <1.6
+    , diagrams-lib          >=1.4  && <1.6
     , foldl                 >=1.4  && <1.5
     , gerber
     , gerber-diagrams
-    , optparse-applicative  >=0.18 && <0.19
+    , optparse-applicative  >=0.17 && <0.19
     , rio                   >=0.1  && <0.2
-    , text                  >=2.1  && <2.2
+    , text                  >=2.0  && <2.2
 
   default-language: Haskell2010
   ghc-options:      -Wall
@@ -51,23 +51,23 @@ executable render-gerbers
 
 test-suite tests
   build-depends:
-    , base              >=4.20 && <4.21
-    , bytestring        >=0.12 && <0.13
-    , containers        >=0.7  && <0.8
-    , diagrams-cairo    >=1.5  && <1.6
-    , diagrams-lib      >=1.5  && <1.6
+    , base              >=4.17 && <4.21
+    , bytestring        >=0.11 && <0.13
+    , containers        >=0.6  && <0.8
+    , diagrams-cairo    >=1.4  && <1.6
+    , diagrams-lib      >=1.4  && <1.6
     , directory         >=1.3  && <1.4
     , foldl             >=1.4  && <1.5
     , generic-deriving  >=1.14 && <1.15
     , gerber
     , gerber-diagrams
-    , linear            >=1.23 && <1.24
-    , megaparsec        >=9.7  && <9.8
-    , monoid-extras     >=0.7  && <0.8
+    , linear            >=1.22 && <1.24
+    , megaparsec        >=9.3  && <9.8
+    , monoid-extras     >=0.6  && <0.8
     , pretty-show       >=1.10 && <1.11
-    , tasty             >=1.5  && <1.6
+    , tasty             >=1.4  && <1.6
     , tasty-golden      >=2.3  && <2.4
-    , text              >=2.1  && <2.2
+    , text              >=2.0  && <2.2
 
   main-is:          Main.hs
   hs-source-dirs:   tests

--- a/gerber-diagrams/lib/Gerber/Diagrams.hs
+++ b/gerber-diagrams/lib/Gerber/Diagrams.hs
@@ -17,7 +17,7 @@ module Gerber.Diagrams (
 ) where
 
 -- base
-import Data.List (unfoldr)
+import Data.List (foldl', unfoldr)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Typeable (Typeable)
 

--- a/gerber/gerber.cabal
+++ b/gerber/gerber.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               gerber
-version:            0.4.0.0
+version:            0.5.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Oliver Charles
@@ -55,17 +55,17 @@ library
     Gerber.Unit
 
   build-depends:
-    , base               >=4.20 && <4.21
+    , base               >=4.17 && <4.21
     , base16-bytestring  >=1.0  && <1.1
-    , bytestring         >=0.12 && <0.13
-    , containers         >=0.7  && <0.8
+    , bytestring         >=0.11 && <0.13
+    , containers         >=0.6  && <0.8
     , foldl              >=1.4  && <1.5
     , generic-deriving   >=1.14 && <1.15
-    , linear             >=1.23 && <1.24
-    , megaparsec         >=9.7  && <9.8
-    , monoid-extras      >=0.7  && <0.8
-    , mtl                >=2.3  && <2.4
-    , text               >=2.1  && <2.2
+    , linear             >=1.22 && <1.24
+    , megaparsec         >=9.3  && <9.8
+    , monoid-extras      >=0.6  && <0.8
+    , mtl                >=2.2  && <2.4
+    , text               >=2.0  && <2.2
     , time               >=1.12 && <1.13
     , uuid-types         >=1.0  && <1.1
 
@@ -82,23 +82,23 @@ library
 
 test-suite tests
   build-depends:
-    , base              >=4.20 && <4.21
-    , bytestring        >=0.12 && <0.13
-    , containers        >=0.7  && <0.8
+    , base              >=4.17 && <4.21
+    , bytestring        >=0.11 && <0.13
+    , containers        >=0.6  && <0.8
     , directory         >=1.3  && <1.4
     , foldl             >=1.4  && <1.5
     , generic-deriving  >=1.14 && <1.15
     , gerber
-    , hedgehog          >=1.5  && <1.6
+    , hedgehog          >=1.2  && <1.6
     , hedgehog-classes  >=0.2  && <0.3
-    , linear            >=1.23 && <1.24
-    , megaparsec        >=9.7  && <9.8
-    , monoid-extras     >=0.7  && <0.8
+    , linear            >=1.22 && <1.24
+    , megaparsec        >=9.3  && <9.8
+    , monoid-extras     >=0.6  && <0.8
     , pretty-show       >=1.10 && <1.11
-    , tasty             >=1.5  && <1.6
+    , tasty             >=1.4  && <1.6
     , tasty-golden      >=2.3  && <2.4
     , tasty-hedgehog    >=1.4  && <1.5
-    , text              >=2.1  && <2.2
+    , text              >=2.0  && <2.2
 
   main-is:          Main.hs
   hs-source-dirs:   tests

--- a/gerber/lib/Gerber/EncodedDecimal.hs
+++ b/gerber/lib/Gerber/EncodedDecimal.hs
@@ -8,6 +8,7 @@ module Gerber.EncodedDecimal (EncodedDecimal (EncodedDecimal, StoredEncodedDecim
 
 -- base
 import Data.Int
+import Data.List (foldl')
 import Data.Word
 
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,22 @@
 let
   pkgs = import
     (fetchTarball {
-      name = "release-23.11";
+
+      # Note we should make sure everything builds with lower bound and upper bound package
+      # set which requires having some warnings in when compiling in both, e.g. in the lower
+      # bound we need to import Data.List (foldl') and in the upper bound this is a warning
+      # for an unused import. Technically I guess we could use CPP to clean this up but that
+      # is more work.
+
+      # the current upper bound
+      name = "release-25.11";
       url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.11.tar.gz";
       sha256 = sha256:1zn1lsafn62sz6azx6j735fh4vwwghj8cc9x91g5sx2nrg23ap9k;
+
+      # # the original lower bound for packages
+      # name = "release-23.11";
+      # url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+      # sha256 = sha256:1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k;
     })
     { config = { allowBroken = true; }; };
 


### PR DESCRIPTION
We relax the lower version bounds of the dependencies to what the shell.nix originally provided and with which everything still compiles and tests succeed. This does mean we have to live with some build warnings both when compiling at the lower and upper dependency bounds.

We also bump the package version numbers since this is a breaking change.